### PR TITLE
It's possible for OPENPOSE_LOG4CXX to exist but be 0. 

### DIFF
--- a/src/OMPLConversions.cpp
+++ b/src/OMPLConversions.cpp
@@ -72,7 +72,7 @@ void OpenRAVEHandler::log(std::string const &text, ompl::msg::LogLevel level,
 
     if (openrave_message_level >= openrave_threshold_level)
     {
-#ifdef OPENRAVE_LOG4CXX
+#if OPENRAVE_LOG4CXX
         log4cxx::spi::LocationInfo const location_info(
             OpenRAVE::RaveGetSourceFilename(filename), "", line);
         OpenRAVE::RavePrintfA_DEBUGLEVEL(


### PR DESCRIPTION
See defn at  https://github.com/rdiankov/openrave/blob/b2818fb534cd8c4e64ea1dddea0f7c360ce5056d/CMakeLists.txt#L740 and usage at https://github.com/rdiankov/openrave/blob/master/include/openrave/logging.h